### PR TITLE
bblayers.conf.sample: add meta-linaro-toolchain

### DIFF
--- a/bblayers.conf.sample
+++ b/bblayers.conf.sample
@@ -12,6 +12,7 @@ BBLAYERS = " \
   \
   ${BSPDIR}/sources/meta-rpb \
   ${BSPDIR}/sources/meta-96boards \
+  ${BSPDIR}/sources/meta-linaro/meta-linaro-toolchain \
   \
   ${BSPDIR}/sources/meta-qcom \
   ${BSPDIR}/sources/meta-browser \


### PR DESCRIPTION
The meta-rpb layer requests the use of the linaro-5% toolchain, so make the
linaro toolchain layer available.

Signed-off-by: Trevor Woerner twoerner@gmail.com
