### PR TITLE
local.conf.sample: accept rpb toolchain

### DIFF
--- a/local.conf.sample
+++ b/local.conf.sample
@@ -205,6 +205,3 @@ CONF_VERSION = "1"
 DISTRO ?= "rpb"
 
 DEFAULTTUNE_armv7a="armv7athf-neon"
-
-# 5.x has issues with mesa, revert to 4.9 for now
-GCCVERSION_armv7a="4.9.3"


### PR DESCRIPTION
The issues that existed with Mesa having problems with gcc-5x seem to be done,
the build succeeds with the toolchain that meta-rpb (Reference Platform Build,
i.e. the DISTRO) wants to use.

Signed-off-by: Trevor Woerner twoerner@gmail.com
